### PR TITLE
Fix incorrect indentation of notebook content

### DIFF
--- a/js/src/thoth.ts
+++ b/js/src/thoth.ts
@@ -262,7 +262,7 @@ export function gather_library_usage( cells?: CodeCell[] ): Promise<string[]> {
             _STD_LIB = {p.name.rstrip(".py") for p in _STD_LIB_PATH.iterdir()}
 
             tree = ast.parse('''
-            ${notebook_content }
+            \n${ notebook_content }
             ''')
 
             visitor = invectio.lib.InvectioVisitor()


### PR DESCRIPTION
Fixes: #42

There seemed to have been an issue with the first line of notebook content being
incorrectly indented, causing successive python calls to fail.

Signed-off-by: Marek Cermak <macermak@redhat.com>

modified:   src/thoth.ts